### PR TITLE
Pull latest changes from master (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ src.esp32/*
 src.mingw/*
 LASER310EMU.exe
 *.o
-sdkconfig.esp32dev
+

--- a/src/emu.h
+++ b/src/emu.h
@@ -105,9 +105,6 @@ extern int	serial_do_log;
 extern int	nic_do_log;
 #endif
 
-extern wchar_t	exe_path[1024];			/* path (dir) of executable */
-extern wchar_t	usr_path[1024];			/* path (dir) of user data */
-extern wchar_t  cfg_path[1024];			/* full path of config file */
 #ifndef USE_NEW_DYNAREC
 extern FILE	*stdlog;			/* file to log output to */
 #endif

--- a/src/gbldefs.h
+++ b/src/gbldefs.h
@@ -12,16 +12,5 @@
 #define EMU_VERSION_W	L"2020-06"
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-extern wchar_t	exe_path[1024];			/* path (dir) of executable */
-extern wchar_t	usr_path[1024];			/* path (dir) of user data */
-extern wchar_t  cfg_path[1024];			/* full path of config file */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	//GBLVAR_H_

--- a/src/gblvar.c
+++ b/src/gblvar.c
@@ -1,7 +1,0 @@
-#include <stdint.h>
-#include <wchar.h>
-#include <stdarg.h>
-
-//wchar_t	exe_path[1024];				/* path (dir) of executable */
-//wchar_t	usr_path[1024];				/* path (dir) of user data */
-//wchar_t	cfg_path[1024];				/* full path of config file */

--- a/src/plat/win/plat.h
+++ b/src/plat/win/plat.h
@@ -83,7 +83,7 @@ extern void	plat_put_backslash(wchar_t *s);
 extern void	plat_path_slash(wchar_t *path);
 extern int	plat_path_abs(wchar_t *path);
 extern int	plat_dir_check(wchar_t *path);
-extern int	plat_dir_create(wchar_t *path);
+//extern int	plat_dir_create(wchar_t *path);
 extern uint64_t	plat_timer_read(void);
 extern uint32_t	plat_get_ticks(void);
 extern void	plat_delay_ms(uint32_t count);

--- a/src/plat/win/plat_win.c
+++ b/src/plat/win/plat_win.c
@@ -35,12 +35,6 @@
 #include "plat.h"
 #include "plat_win.h"
 
-//#include "ui.h"
-
-
-//#include "win.h"
-#include "win_gblvar.h"
-
 
 /* Platform Public data, specific. */
 HINSTANCE	hinstance;		/* application instance */
@@ -405,12 +399,12 @@ plat_dir_check(wchar_t *path)
 	   (dwAttrib & FILE_ATTRIBUTE_DIRECTORY))) ? 1 : 0);
 }
 
-
-int
-plat_dir_create(wchar_t *path)
-{
-    return((int)SHCreateDirectory(hwndMain, path));
-}
+//TODO, Currently, not used. Switch to use POXIS function instead
+// int
+// plat_dir_create(wchar_t *path)
+// {
+//     return((int)SHCreateDirectory(hwndMain, path));
+// }
 
 
 uint64_t

--- a/src/utils/prgdef.c
+++ b/src/utils/prgdef.c
@@ -2,7 +2,3 @@
 
 uint8_t tmp_buf[TMP_BUF_LEN];
 
-//wchar_t	exe_path[1024];				/* path (dir) of executable */
-//wchar_t	usr_path[1024];				/* path (dir) of user data */
-//wchar_t	cfg_path[1024];				/* full path of config file */
-

--- a/src/utils/prgdef.h
+++ b/src/utils/prgdef.h
@@ -7,12 +7,8 @@
 #include <stdint.h>
 #endif
 
-//TODO, BY - need to refactor 
-#ifdef  __MINGW64__
-#define TMP_BUF_LEN	0x100000        //1MB buffer
-#elif   ESP32
-#define TMP_BUF_LEN	0x20000         //128KB buffer
-#endif
+//TODO, refactor to use dynamic allocation. This utility buffer is shared by fd.c and FileIO.c
+#define TMP_BUF_LEN	0x20000     //128KB
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/win/SDLFunctions.c
+++ b/src/win/SDLFunctions.c
@@ -5,8 +5,8 @@
 #include "plat/plat.h"
 #include "plat/win/plat_win.h"
 
+#include "gbldefs.h"
 #include "win_gblvar.h"
-#include "gblvar.h"
 
 #include "emu.h"
 #include "emu_core.h"

--- a/src/win/WinMain.c
+++ b/src/win/WinMain.c
@@ -22,11 +22,8 @@
 #include "plat_win.h"
 #include "wchar2char.h"
 
-
-
-#include "gblvar.h"
+#include "gbldefs.h"
 #include "win_gblvar.h"
-
 
 #include "vz.h"
 #include "dsk.h"


### PR DESCRIPTION
* Code cleanup (#5)

* Updated gitignore list

* makefile -> UTF8

makefile -> UTF8

* Code cleanup

1. defined root plat.h for MINGW64
2. Removed unused variables
3. emu_close function parameter -> threadid

* Pull latest changes from master (#4)

* More code cleanups (#3)

* Updated gitignore list

* makefile -> UTF8

makefile -> UTF8

* Code cleanup

1. defined root plat.h for MINGW64
2. Removed unused variables
3. emu_close function parameter -> threadid

* Updated readme with build instructions

* Exclude *.o

* Removed windows.h include

* Updated gitignore

* Removed sdl2/sdl.h references from core files

* Moved codegen

Moved z80user.h to src\z80
Moved codegen,gen_vkey to build_root\tools folder

* added return to EmulationInitialize function

* Fixed compiler errors

* set screen update callback

* emu_exit control

* Temporarily deleted platformio files

* Code cleanup (#7)

Renamed rom files for better compatibility of other platforms
Deleted unused variable references
Renamed gblvar.h to gbldefs.h
Commented out plat_dir_created, it's not used.
Reduced tmp_buf to 128KB