### PR TITLE
Mingw cleanup (#10)

### DIFF
--- a/src/win/WinMain.c
+++ b/src/win/WinMain.c
@@ -88,7 +88,6 @@ extern int sdlwin_ready;
 uint8_t	fontrom[0x1000];
 uint8_t sysrom[0x4000];
 uint8_t	dosrom[0x2000];
-uint8_t	vzfrom[0x10000];
 
 HANDLE hRomFile;
 HANDLE logFile;


### PR DESCRIPTION
* Code cleanup

Renamed rom files for better compatibility of other platforms
Deleted unused variable references
Renamed gblvar.h to gbldefs.h
Commented out plat_dir_created, it's not used.
Reduced tmp_buf to 128KB

* Removed unused vzfrom